### PR TITLE
fix: handle auth errors in save endpoint

### DIFF
--- a/archivooor/archiver.py
+++ b/archivooor/archiver.py
@@ -99,6 +99,8 @@ class Archiver:
             url = future_to_url[future]
             try:
                 results.append(future.result())
+            except exceptions.ArchivooorException:
+                raise
             except Exception as exc:
                 failures.append(url)
         if failures:
@@ -176,9 +178,15 @@ class Archiver:
             }
             return formatted_response
 
+        elif response.status_code == 401:
+            raise exceptions.ArchivooorException(
+                "Unauthorized - Please check if the keys are correct."
+            )
         else:
             formatted_response = {
                 "url": url,
+                "status": "error",
+                "message": f"HTTP {response.status_code}",
                 "status_code": response.status_code,
                 "full_response": response.text,
             }

--- a/archivooor/cli.py
+++ b/archivooor/cli.py
@@ -2,7 +2,7 @@
 
 import click
 
-from archivooor import archiver, key_utils
+from archivooor import archiver, exceptions, key_utils
 
 
 @click.group(
@@ -46,15 +46,18 @@ def save(urls, verbose):
         click.echo(save.get_help(click.Context(save)))
         return
 
-    responses = click.get_current_context().obj.save_pages(
-        pages=list(urls),
-        capture_all=True,
-        capture_outlinks=True,
-        force_get=True,
-        capture_screenshot=True,
-        skip_first_archive=True,
-        outlinks_availability=True,
-    )
+    try:
+        responses = click.get_current_context().obj.save_pages(
+            pages=list(urls),
+            capture_all=True,
+            capture_outlinks=True,
+            force_get=True,
+            capture_screenshot=True,
+            skip_first_archive=True,
+            outlinks_availability=True,
+        )
+    except exceptions.ArchivooorException as e:
+        raise click.ClickException(str(e))
     if verbose:
         for response in responses:
             for key, value in response.items():


### PR DESCRIPTION
The save endpoint returns 401 for invalid credentials, but the response dict lacked `status`/`job_id` keys, causing the CLI to print "None" for both instead of a meaningful error message.