### PR TITLE
feat: add SQLite-backed history tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,14 +17,15 @@ uv run ruff format        # format only
 uv run mypy archivooor    # type check only
 ```
 
-No unit test suite exists. CI runs CLI integration checks (help output, keyring set/delete) across Python 3.9–3.13 on ubuntu/macos/windows.
+Unit tests live in `tests/` (pytest). CI also runs CLI integration checks (help output, keyring set/delete) across Python 3.9–3.13 on ubuntu/macos/windows.
 
 ## Architecture
 
 All source lives in `archivooor/`:
 
-- **`archiver.py`** — Core logic. `Archiver` class handles save/status API calls with S3 auth headers. `NetworkHandler` wraps requests.Session with urllib3 retry (5 retries, exponential backoff). `Sitemap` parses XML sitemaps into URL lists. `save_pages()` uses ThreadPoolExecutor (5 workers) with recursive retry on failures.
-- **`cli.py`** — Click CLI. Commands: `save`, `job`, `stats`, `keys set`, `keys delete`. Loads credentials via `key_utils` in the group callback.
+- **`archiver.py`** — Core logic. `Archiver` class handles save/status API calls with S3 auth headers, integrates with `HistoryDB` for tracking (on by default, `track_history=False` to disable). `NetworkHandler` wraps requests.Session with urllib3 retry (5 retries, exponential backoff). `Sitemap` parses XML sitemaps into URL lists. `save_pages()` uses ThreadPoolExecutor (5 workers) with recursive retry on failures and fire-and-forget background polling for completion status.
+- **`history.py`** — SQLite-backed history tracking. `HistoryDB` class with per-thread connections (WAL mode), `PRAGMA user_version` schema migrations. Records submissions, polls for completion, supports filtered queries and clearing.
+- **`cli.py`** — Click CLI. Commands: `save`, `job`, `stats`, `history` (with `--url`/`--status`/`--since`/`--limit`/`--json` filters), `history clear`, `keys set`, `keys delete`. Global `--no-history` flag disables tracking. Loads credentials via `key_utils` in the group callback.
 - **`key_utils.py`** — Credential resolution: env vars (`s3_access_key`, `s3_secret_key`) checked first, then system keyring fallback.
 - **`exceptions.py`** — Single `ArchivooorException` base class.
 

--- a/archivooor/archiver.py
+++ b/archivooor/archiver.py
@@ -1,14 +1,20 @@
+from __future__ import annotations
+
 import concurrent.futures
 import logging
 import re
 import time
 import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING, Optional
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from archivooor import exceptions
+
+if TYPE_CHECKING:
+    from archivooor.history import HistoryDB
 
 logger = logging.getLogger(__name__)
 MAX_RETRIES = 3
@@ -45,23 +51,38 @@ class Archiver:
     Used for authenticating and interacting with the archive.org API.
     """
 
-    def __init__(self, s3_access_key, s3_secret_key):
-        """
-        Initialize the object
-        :param s3_access_key: s3_access_key
-        :param s3_secret_key: s3_secret_key
-        """
-
+    def __init__(
+        self,
+        s3_access_key: Optional[str],
+        s3_secret_key: Optional[str],
+        *,
+        db_path: Optional[str] = None,
+        track_history: bool = True,
+    ):
         self.s3_access_key = s3_access_key
         self.s3_secret_key = s3_secret_key
-        self.session = NetworkHandler().session
-        self.executor = NetworkHandler().executor
+        handler = NetworkHandler()
+        self.session = handler.session
+        self.executor = handler.executor
 
         headers = {
             "Accept": "application/json",
             "Authorization": f"LOW {self.s3_access_key}:{self.s3_secret_key}",
         }
         self.session.headers.update(headers)
+
+        self._history: Optional[HistoryDB] = None
+        if track_history:
+            try:
+                from archivooor.history import HistoryDB
+
+                self._history = HistoryDB(db_path=db_path)
+            except Exception:
+                logger.debug("Failed to initialize history DB", exc_info=True)
+
+    @property
+    def history(self) -> Optional[HistoryDB]:
+        return self._history
 
     def save_pages(
         self,
@@ -101,8 +122,15 @@ class Archiver:
                 results.append(future.result())
             except exceptions.ArchivooorException:
                 raise
-            except Exception as exc:
+            except Exception:
                 failures.append(url)
+
+        if self._history:
+            for result in results:
+                job_id = result.get("job_id") if isinstance(result, dict) else None
+                if job_id:
+                    self.executor.submit(self._poll_and_update, job_id)
+
         if failures:
             if _retries >= MAX_RETRIES:
                 logger.warning(
@@ -176,6 +204,7 @@ class Archiver:
                 "status": status,
                 "full_response": data,
             }
+            self._record_history(url, data.get("job_id"), status)
             return formatted_response
 
         elif response.status_code == 401:
@@ -190,6 +219,7 @@ class Archiver:
                 "status_code": response.status_code,
                 "full_response": response.text,
             }
+            self._record_history(url, None, "error")
             return formatted_response
 
     def get_save_status(self, job_id: str, _retries: int = 0):
@@ -245,6 +275,38 @@ class Archiver:
             raise exceptions.ArchivooorException(
                 f"Unexpected error: {response.status_code} - {response.text}"
             )
+
+    def _record_history(self, url: str, job_id: Optional[str], status: str) -> None:
+        if not self._history:
+            return
+        try:
+            self._history.record_submission(url, job_id, status)
+        except Exception:
+            logger.debug("Failed to record history for %s", url, exc_info=True)
+
+    def _poll_and_update(
+        self, job_id: str, max_polls: int = 30, poll_interval: int = 6
+    ) -> None:
+        try:
+            for _ in range(max_polls):
+                data = self.get_save_status(job_id)
+                if isinstance(data, dict) and data.get("status") in (
+                    "success",
+                    "error",
+                ):
+                    if self._history:
+                        self._history.update_completion(
+                            job_id=job_id,
+                            status=data["status"],
+                            original_url=data.get("original_url"),
+                            timestamp=data.get("timestamp"),
+                            duration_sec=data.get("duration_sec"),
+                            status_ext=data.get("status_ext"),
+                        )
+                    return
+                time.sleep(poll_interval)
+        except Exception:
+            logger.debug("Poll failed for job %s", job_id, exc_info=True)
 
 
 class Sitemap:

--- a/archivooor/cli.py
+++ b/archivooor/cli.py
@@ -168,20 +168,20 @@ def history(ctx, url, status, since, limit, as_json):
         click.echo("No submissions found.")
         return
 
-    header = f"{'URL':<40} {'Job ID':<20} {'Status':<10} {'Submitted':<20} {'WM Timestamp':<16}"
+    header = f"{'URL':<50} {'Job ID':<36} {'Status':<10} {'Submitted':<20} {'WM Timestamp':<16}"
     click.echo(header)
     click.echo("-" * len(header))
     for row in rows:
         u = row["url"]
-        if len(u) > 39:
-            u = u[:38] + "…"
+        if len(u) > 49:
+            u = u[:48] + "…"
         jid = row.get("job_id") or ""
-        if len(jid) > 19:
-            jid = jid[:18] + "…"
+        if len(jid) > 35:
+            jid = jid[:34] + "…"
         st = row.get("status") or ""
         sub = (row.get("submitted_at") or "")[:19]
         ts = row.get("timestamp") or ""
-        click.echo(f"{u:<40} {jid:<20} {st:<10} {sub:<20} {ts:<16}")
+        click.echo(f"{u:<50} {jid:<36} {st:<10} {sub:<20} {ts:<16}")
 
 
 @history.command(name="clear")

--- a/archivooor/cli.py
+++ b/archivooor/cli.py
@@ -168,7 +168,7 @@ def history(ctx, url, status, since, limit, as_json):
         click.echo("No submissions found.")
         return
 
-    header = f"{'URL':<50} {'Job ID':<36} {'Status':<10} {'Submitted':<20} {'WM Timestamp':<20}"
+    header = f"{'URL':<50} {'Job ID':<46} {'Status':<10} {'Submitted':<20} {'WM Timestamp':<20}"
     click.echo(header)
     click.echo("-" * len(header))
     for row in rows:
@@ -176,8 +176,6 @@ def history(ctx, url, status, since, limit, as_json):
         if len(u) > 49:
             u = u[:48] + "…"
         jid = row.get("job_id") or ""
-        if len(jid) > 35:
-            jid = jid[:34] + "…"
         st = row.get("status") or ""
         sub = (row.get("submitted_at") or "")[:19]
         ts_raw = row.get("timestamp") or ""
@@ -189,7 +187,7 @@ def history(ctx, url, status, since, limit, as_json):
             )
         except (IndexError, TypeError):
             ts = ts_raw
-        click.echo(f"{u:<50} {jid:<36} {st:<10} {sub:<20} {ts:<20}")
+        click.echo(f"{u:<50} {jid:<46} {st:<10} {sub:<20} {ts:<20}")
 
 
 @history.command(name="clear")

--- a/archivooor/cli.py
+++ b/archivooor/cli.py
@@ -1,5 +1,7 @@
 """Command line interface for the archivooor package."""
 
+import json
+
 import click
 
 from archivooor import archiver, exceptions, key_utils
@@ -12,8 +14,11 @@ from archivooor import archiver, exceptions, key_utils
     }
 )
 @click.version_option()
+@click.option(
+    "--no-history", is_flag=True, default=False, help="Disable history tracking"
+)
 @click.pass_context
-def cli(ctx):
+def cli(ctx, no_history):
     """Easily interact with the archive.org API.
 
     Submit webpages to the Wayback Machine and check the save job status.
@@ -23,9 +28,14 @@ def cli(ctx):
         archive = archiver.Archiver(
             s3_access_key=credentials[0],
             s3_secret_key=credentials[1],
+            track_history=not no_history,
         )
     else:
-        archive = archiver.Archiver(s3_access_key=None, s3_secret_key=None)
+        archive = archiver.Archiver(
+            s3_access_key=None,
+            s3_secret_key=None,
+            track_history=not no_history,
+        )
     ctx.obj = archive
 
 
@@ -122,6 +132,69 @@ def set_keys(access_key, secret_key):
 def delete_keys():
     """Delete your archive.org API keys."""
     key_utils.delete_credentials()
+
+
+@cli.group(name="history", invoke_without_command=True)
+@click.option("--url", default=None, help="Filter by URL (substring match)")
+@click.option(
+    "--status",
+    default=None,
+    type=click.Choice(["submitted", "success", "error", "failed"]),
+    help="Filter by status",
+)
+@click.option("--since", default=None, help="Show entries since ISO 8601 date")
+@click.option("--limit", default=20, type=int, help="Max rows to return")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+@click.pass_context
+def history(ctx, url, status, since, limit, as_json):
+    """View archival history.
+
+    Shows past submissions and their outcomes.
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+
+    archive = ctx.obj
+    if archive.history is None:
+        raise click.ClickException("History tracking is disabled (--no-history)")
+
+    rows = archive.history.query(url=url, status=status, since=since, limit=limit)
+
+    if as_json:
+        click.echo(json.dumps(rows, indent=2))
+        return
+
+    if not rows:
+        click.echo("No submissions found.")
+        return
+
+    header = f"{'URL':<40} {'Job ID':<20} {'Status':<10} {'Submitted':<20} {'WM Timestamp':<16}"
+    click.echo(header)
+    click.echo("-" * len(header))
+    for row in rows:
+        u = row["url"]
+        if len(u) > 39:
+            u = u[:38] + "…"
+        jid = row.get("job_id") or ""
+        if len(jid) > 19:
+            jid = jid[:18] + "…"
+        st = row.get("status") or ""
+        sub = (row.get("submitted_at") or "")[:19]
+        ts = row.get("timestamp") or ""
+        click.echo(f"{u:<40} {jid:<20} {st:<10} {sub:<20} {ts:<16}")
+
+
+@history.command(name="clear")
+@click.confirmation_option(prompt="Delete all history?")
+@click.pass_context
+def history_clear(ctx):
+    """Clear all archival history."""
+    archive = ctx.obj
+    if archive.history is None:
+        raise click.ClickException("History tracking is disabled (--no-history)")
+
+    count = archive.history.clear()
+    click.echo(f"Deleted {count} entries.")
 
 
 if __name__ == "__main__":

--- a/archivooor/cli.py
+++ b/archivooor/cli.py
@@ -168,7 +168,7 @@ def history(ctx, url, status, since, limit, as_json):
         click.echo("No submissions found.")
         return
 
-    header = f"{'URL':<50} {'Job ID':<36} {'Status':<10} {'Submitted':<20} {'WM Timestamp':<16}"
+    header = f"{'URL':<50} {'Job ID':<36} {'Status':<10} {'Submitted':<20} {'WM Timestamp':<20}"
     click.echo(header)
     click.echo("-" * len(header))
     for row in rows:
@@ -180,8 +180,16 @@ def history(ctx, url, status, since, limit, as_json):
             jid = jid[:34] + "…"
         st = row.get("status") or ""
         sub = (row.get("submitted_at") or "")[:19]
-        ts = row.get("timestamp") or ""
-        click.echo(f"{u:<50} {jid:<36} {st:<10} {sub:<20} {ts:<16}")
+        ts_raw = row.get("timestamp") or ""
+        try:
+            ts = (
+                f"{ts_raw[:4]}-{ts_raw[4:6]}-{ts_raw[6:8]} {ts_raw[8:10]}:{ts_raw[10:12]}:{ts_raw[12:14]}"
+                if len(ts_raw) >= 14
+                else ts_raw
+            )
+        except (IndexError, TypeError):
+            ts = ts_raw
+        click.echo(f"{u:<50} {jid:<36} {st:<10} {sub:<20} {ts:<20}")
 
 
 @history.command(name="clear")

--- a/archivooor/history.py
+++ b/archivooor/history.py
@@ -1,0 +1,141 @@
+"""SQLite-backed history tracking for archival submissions."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+_SCHEMA_SQL = """\
+CREATE TABLE IF NOT EXISTS submissions (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    url           TEXT    NOT NULL,
+    job_id        TEXT    UNIQUE,
+    submitted_at  TEXT    NOT NULL,
+    status        TEXT    NOT NULL,
+    original_url  TEXT,
+    timestamp     TEXT,
+    duration_sec  REAL,
+    status_ext    TEXT,
+    completed_at  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_submissions_url ON submissions (url);
+CREATE INDEX IF NOT EXISTS idx_submissions_status ON submissions (status);
+CREATE INDEX IF NOT EXISTS idx_submissions_submitted_at ON submissions (submitted_at);
+"""
+
+
+def _default_db_path() -> str:
+    try:
+        import click
+
+        app_dir = click.get_app_dir("archivooor")
+    except ImportError:
+        app_dir = os.path.join(os.path.expanduser("~"), ".config", "archivooor")
+    return os.path.join(app_dir, "history.db")
+
+
+class HistoryDB:
+    def __init__(self, db_path: Optional[str] = None):
+        self.db_path = db_path or _default_db_path()
+        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+        self._local = threading.local()
+        conn = self._get_connection()
+        self._init_db(conn)
+
+    def _get_connection(self) -> sqlite3.Connection:
+        conn = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self.db_path, timeout=10)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            self._local.conn = conn
+        return conn
+
+    def _init_db(self, conn: sqlite3.Connection) -> None:
+        (version,) = conn.execute("PRAGMA user_version").fetchone()
+        if version < SCHEMA_VERSION:
+            conn.executescript(_SCHEMA_SQL)
+            conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+            conn.commit()
+
+    def record_submission(
+        self, url: str, job_id: Optional[str], status: str
+    ) -> Optional[int]:
+        conn = self._get_connection()
+        now = datetime.now(timezone.utc).isoformat()
+        try:
+            cur = conn.execute(
+                "INSERT INTO submissions (url, job_id, submitted_at, status) VALUES (?, ?, ?, ?)",
+                (url, job_id, now, status),
+            )
+            conn.commit()
+            return cur.lastrowid
+        except sqlite3.IntegrityError:
+            logger.debug("Duplicate job_id %s for url %s", job_id, url)
+            return None
+
+    def update_completion(
+        self,
+        job_id: str,
+        status: str,
+        original_url: Optional[str] = None,
+        timestamp: Optional[str] = None,
+        duration_sec: Optional[float] = None,
+        status_ext: Optional[str] = None,
+    ) -> None:
+        conn = self._get_connection()
+        now = datetime.now(timezone.utc).isoformat()
+        conn.execute(
+            """\
+            UPDATE submissions
+            SET status = ?, original_url = ?, timestamp = ?,
+                duration_sec = ?, status_ext = ?, completed_at = ?
+            WHERE job_id = ?""",
+            (status, original_url, timestamp, duration_sec, status_ext, now, job_id),
+        )
+        conn.commit()
+
+    def query(
+        self,
+        url: Optional[str] = None,
+        status: Optional[str] = None,
+        since: Optional[str] = None,
+        limit: int = 20,
+    ) -> list[dict]:
+        conn = self._get_connection()
+        clauses: list[str] = []
+        params: list[object] = []
+        if url:
+            clauses.append("url LIKE ?")
+            params.append(f"%{url}%")
+        if status:
+            clauses.append("status = ?")
+            params.append(status)
+        if since:
+            clauses.append("submitted_at >= ?")
+            params.append(since)
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        sql = f"SELECT * FROM submissions{where} ORDER BY submitted_at DESC LIMIT ?"
+        params.append(limit)
+        rows = conn.execute(sql, params).fetchall()
+        return [dict(row) for row in rows]
+
+    def clear(self) -> int:
+        conn = self._get_connection()
+        cur = conn.execute("DELETE FROM submissions")
+        conn.commit()
+        return cur.rowcount
+
+    def close(self) -> None:
+        conn = getattr(self._local, "conn", None)
+        if conn is not None:
+            conn.close()
+            self._local.conn = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archivooor"
-version = "0.0.10"
+version = "0.1.0"
 description = "A Python package to submit web pages to the Wayback Machine for archiving."
 authors = [
     { name = "Barabazs", email = "31799121+Barabazs@users.noreply.github.com" },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,21 @@ import pytest
 import responses
 
 from archivooor.archiver import Archiver
+from archivooor.history import HistoryDB
 
 
 @pytest.fixture
 def archiver():
     with responses.RequestsMock() as rsps:
-        a = Archiver("test_access", "test_secret")
+        a = Archiver("test_access", "test_secret", track_history=False)
         yield a, rsps
+
+
+@pytest.fixture
+def history_db(tmp_path):
+    db = HistoryDB(db_path=str(tmp_path / "test_history.db"))
+    yield db
+    db.close()
 
 
 SAMPLE_URLSET_XML = """\

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -14,6 +14,7 @@ from archivooor.archiver import (
     NetworkHandler,
 )
 from archivooor.exceptions import ArchivooorException
+from archivooor.history import HistoryDB
 
 SAVE_URL_RE = re.compile(r"https://web\.archive\.org/save/.*")
 STATUS_URL_RE = re.compile(r"https://web\.archive\.org/save/status/.*")
@@ -241,3 +242,62 @@ class TestNetworkHandler:
     def test_executor_max_workers(self):
         nh = NetworkHandler()
         assert nh.executor._max_workers == 5
+
+
+class TestArchiverWithHistory:
+    @pytest.fixture
+    def archiver_with_history(self, tmp_path):
+        db_path = str(tmp_path / "history.db")
+        with responses.RequestsMock() as rsps:
+            a = Archiver(
+                "test_access", "test_secret", db_path=db_path, track_history=True
+            )
+            yield a, rsps
+
+    def test_save_page_records_submission(self, archiver_with_history):
+        a, rsps = archiver_with_history
+        rsps.post(SAVE_URL_RE, json={"job_id": "abc"}, status=200)
+
+        a.save_page("https://example.com")
+
+        rows = a.history.query()
+        assert len(rows) == 1
+        assert rows[0]["url"] == "https://example.com"
+        assert rows[0]["job_id"] == "abc"
+        assert rows[0]["status"] == "submitted"
+
+    def test_save_page_records_error(self, archiver_with_history):
+        a, rsps = archiver_with_history
+        rsps.post(SAVE_URL_RE, body="Bad Request", status=400)
+
+        a.save_page("https://example.com")
+
+        rows = a.history.query()
+        assert len(rows) == 1
+        assert rows[0]["status"] == "error"
+
+    def test_history_disabled(self, tmp_path):
+        with responses.RequestsMock() as rsps:
+            a = Archiver("test_access", "test_secret", track_history=False)
+            assert a.history is None
+
+    def test_save_pages_triggers_poll(self, archiver_with_history):
+        a, rsps = archiver_with_history
+        rsps.post(SAVE_URL_RE, json={"job_id": "poll1"}, status=200)
+        rsps.get(
+            STATUS_URL_RE,
+            json={
+                "status": "success",
+                "original_url": "https://example.com",
+                "timestamp": "20260425120000",
+                "duration_sec": 2.5,
+            },
+        )
+
+        a.save_pages(["https://example.com"])
+        a.executor.shutdown(wait=True)
+
+        rows = a.history.query()
+        assert len(rows) == 1
+        assert rows[0]["status"] == "success"
+        assert rows[0]["timestamp"] == "20260425120000"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 
 from archivooor.cli import cli
+from archivooor.history import HistoryDB
 
 
 @patch("archivooor.cli.key_utils")
@@ -99,3 +100,110 @@ class TestCli:
 
         assert result.exit_code == 0
         mock_key_utils.delete_credentials.assert_called_once()
+
+    def test_no_history_flag(self, mock_archiver_cls, mock_key_utils):
+        mock_key_utils.get_credentials.return_value = ("ak", "sk")
+        mock_archiver_cls.return_value = MagicMock()
+
+        self._runner().invoke(cli, ["--no-history", "save"])
+
+        mock_archiver_cls.assert_called_once_with(
+            s3_access_key="ak",
+            s3_secret_key="sk",
+            track_history=False,
+        )
+
+
+class TestHistoryCli:
+    def _runner(self):
+        return CliRunner()
+
+    def test_history_table_output(self, tmp_path):
+        db = HistoryDB(db_path=str(tmp_path / "h.db"))
+        db.record_submission("https://example.com", "job1", "submitted")
+
+        mock_arch = MagicMock()
+        mock_arch.history = db
+
+        with (
+            patch("archivooor.cli.key_utils") as mk,
+            patch("archivooor.cli.archiver.Archiver", return_value=mock_arch),
+        ):
+            mk.get_credentials.return_value = ("ak", "sk")
+            result = self._runner().invoke(cli, ["history"])
+
+        assert result.exit_code == 0
+        assert "example.com" in result.output
+        assert "job1" in result.output
+        assert "submitted" in result.output
+        db.close()
+
+    def test_history_json_output(self, tmp_path):
+        db = HistoryDB(db_path=str(tmp_path / "h.db"))
+        db.record_submission("https://example.com", "job1", "submitted")
+
+        mock_arch = MagicMock()
+        mock_arch.history = db
+
+        with (
+            patch("archivooor.cli.key_utils") as mk,
+            patch("archivooor.cli.archiver.Archiver", return_value=mock_arch),
+        ):
+            mk.get_credentials.return_value = ("ak", "sk")
+            result = self._runner().invoke(cli, ["history", "--json"])
+
+        assert result.exit_code == 0
+        import json
+
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["url"] == "https://example.com"
+        db.close()
+
+    def test_history_empty(self, tmp_path):
+        db = HistoryDB(db_path=str(tmp_path / "h.db"))
+        mock_arch = MagicMock()
+        mock_arch.history = db
+
+        with (
+            patch("archivooor.cli.key_utils") as mk,
+            patch("archivooor.cli.archiver.Archiver", return_value=mock_arch),
+        ):
+            mk.get_credentials.return_value = ("ak", "sk")
+            result = self._runner().invoke(cli, ["history"])
+
+        assert result.exit_code == 0
+        assert "No submissions found" in result.output
+        db.close()
+
+    def test_history_clear(self, tmp_path):
+        db = HistoryDB(db_path=str(tmp_path / "h.db"))
+        db.record_submission("https://a.com", "j1", "submitted")
+
+        mock_arch = MagicMock()
+        mock_arch.history = db
+
+        with (
+            patch("archivooor.cli.key_utils") as mk,
+            patch("archivooor.cli.archiver.Archiver", return_value=mock_arch),
+        ):
+            mk.get_credentials.return_value = ("ak", "sk")
+            result = self._runner().invoke(cli, ["history", "clear", "--yes"])
+
+        assert result.exit_code == 0
+        assert "Deleted 1 entries" in result.output
+        db.close()
+
+    def test_history_disabled_error(self):
+        mock_arch = MagicMock()
+        mock_arch.history = None
+
+        with (
+            patch("archivooor.cli.key_utils") as mk,
+            patch("archivooor.cli.archiver.Archiver", return_value=mock_arch),
+        ):
+            mk.get_credentials.return_value = ("ak", "sk")
+            result = self._runner().invoke(cli, ["history"])
+
+        assert result.exit_code != 0
+        assert "disabled" in result.output

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,134 @@
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from archivooor.history import HistoryDB
+
+
+@pytest.fixture
+def history_db(tmp_path):
+    db = HistoryDB(db_path=str(tmp_path / "test.db"))
+    yield db
+    db.close()
+
+
+class TestHistoryDB:
+    def test_record_and_query(self, history_db):
+        row_id = history_db.record_submission("https://a.com", "job1", "submitted")
+        assert row_id is not None
+
+        rows = history_db.query()
+        assert len(rows) == 1
+        assert rows[0]["url"] == "https://a.com"
+        assert rows[0]["job_id"] == "job1"
+        assert rows[0]["status"] == "submitted"
+
+    def test_duplicate_job_id_returns_none(self, history_db):
+        history_db.record_submission("https://a.com", "dup1", "submitted")
+        result = history_db.record_submission("https://b.com", "dup1", "submitted")
+        assert result is None
+
+    def test_null_job_id_allows_multiple(self, history_db):
+        id1 = history_db.record_submission("https://a.com", None, "error")
+        id2 = history_db.record_submission("https://b.com", None, "error")
+        assert id1 is not None
+        assert id2 is not None
+
+    def test_update_completion(self, history_db):
+        history_db.record_submission("https://a.com", "job1", "submitted")
+        history_db.update_completion(
+            "job1",
+            status="success",
+            original_url="https://a.com",
+            timestamp="20260425120000",
+            duration_sec=3.5,
+            status_ext=None,
+        )
+
+        rows = history_db.query()
+        assert rows[0]["status"] == "success"
+        assert rows[0]["timestamp"] == "20260425120000"
+        assert rows[0]["duration_sec"] == 3.5
+        assert rows[0]["completed_at"] is not None
+
+    def test_query_filter_url(self, history_db):
+        history_db.record_submission("https://a.com/page1", "j1", "submitted")
+        history_db.record_submission("https://b.com/page2", "j2", "submitted")
+
+        rows = history_db.query(url="a.com")
+        assert len(rows) == 1
+        assert rows[0]["url"] == "https://a.com/page1"
+
+    def test_query_filter_status(self, history_db):
+        history_db.record_submission("https://a.com", "j1", "submitted")
+        history_db.record_submission("https://b.com", "j2", "error")
+
+        rows = history_db.query(status="error")
+        assert len(rows) == 1
+        assert rows[0]["url"] == "https://b.com"
+
+    def test_query_filter_since(self, history_db):
+        history_db.record_submission("https://a.com", "j1", "submitted")
+        future = "2099-01-01T00:00:00"
+        rows = history_db.query(since=future)
+        assert len(rows) == 0
+
+    def test_query_limit(self, history_db):
+        for i in range(10):
+            history_db.record_submission(f"https://a.com/{i}", f"j{i}", "submitted")
+
+        rows = history_db.query(limit=3)
+        assert len(rows) == 3
+
+    def test_query_order_desc(self, history_db):
+        history_db.record_submission("https://first.com", "j1", "submitted")
+        time.sleep(0.01)
+        history_db.record_submission("https://second.com", "j2", "submitted")
+
+        rows = history_db.query()
+        assert rows[0]["url"] == "https://second.com"
+
+    def test_clear(self, history_db):
+        history_db.record_submission("https://a.com", "j1", "submitted")
+        history_db.record_submission("https://b.com", "j2", "submitted")
+
+        count = history_db.clear()
+        assert count == 2
+        assert history_db.query() == []
+
+    def test_thread_safety(self, history_db):
+        errors = []
+
+        def insert(n):
+            try:
+                history_db.record_submission(f"https://{n}.com", f"job{n}", "submitted")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=insert, args=(i,)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(history_db.query(limit=100)) == 20
+
+    def test_schema_version(self, tmp_path):
+        db_path = str(tmp_path / "version.db")
+        db = HistoryDB(db_path=db_path)
+        conn = sqlite3.connect(db_path)
+        (version,) = conn.execute("PRAGMA user_version").fetchone()
+        assert version == 1
+        conn.close()
+        db.close()
+
+    def test_default_db_path(self):
+        db = HistoryDB.__new__(HistoryDB)
+        from archivooor.history import _default_db_path
+
+        path = _default_db_path()
+        assert "archivooor" in path
+        assert path.endswith("history.db")

--- a/uv.lock
+++ b/uv.lock
@@ -3,12 +3,12 @@ revision = 3
 requires-python = ">=3.10, <4.0"
 
 [options]
-exclude-newer = "2026-04-12T11:54:51.92516971Z"
+exclude-newer = "2026-04-18T11:12:04.72907625Z"
 exclude-newer-span = "P1W"
 
 [[package]]
 name = "archivooor"
-version = "0.0.10"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
- Add `HistoryDB` (`history.py`) — SQLite with WAL mode, per-thread connections, `PRAGMA user_version` schema migrations
- Record every submission on save, background-poll for completion status via existing `ThreadPoolExecutor`
- New `history` CLI command with `--url`, `--status`, `--since`, `--limit`, `--json` filters and `history clear` subcommand
- Global `--no-history` flag to disable tracking; DB failures never break saves